### PR TITLE
on macos, fortify_source is already defined 

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ if get_option('buildtype') == 'release'
   add_project_arguments(
     cc.get_supported_arguments(
       [
-        '-U_FORTIFY_SOURCE',
+        '-U_FORTIFY_SOURCE',   # first undefine it since it is already defined on macOS
         '-D_FORTIFY_SOURCE=3', # incompatible with sanitizers, so do it in the release build
       ],
     ),


### PR DESCRIPTION
so we must undefine it on release builds.