### PR TITLE
input: abstract input handling

### DIFF
--- a/input.c
+++ b/input.c
@@ -1,0 +1,32 @@
+#include "input.h"
+#include "raylib.h"
+
+static bool input_key_f(enum KeyAction action, bool (*f)(int)) {
+	switch (action) {
+		case ACTION_NULL:
+			return false;
+		case ACTION_UP: {
+			return f(KEY_UP) || f(KEY_W);
+		}
+		case ACTION_LEFT: {
+			return f(KEY_LEFT) || f(KEY_A);
+		}
+		case ACTION_DOWN: {
+			return f(KEY_DOWN) || f(KEY_S);
+		}
+		case ACTION_RIGHT: {
+			return f(KEY_RIGHT) || f(KEY_D);
+		}
+		case ACTION_EXECUTE: {
+			return f(KEY_SPACE) || f(KEY_ENTER);
+		}
+	}
+}
+
+bool input_key_once(enum KeyAction action) {
+	return input_key_f(action, IsKeyPressed);
+}
+
+bool input_key_down(enum KeyAction action) {
+	return input_key_f(action, IsKeyDown);
+}

--- a/input.h
+++ b/input.h
@@ -1,0 +1,14 @@
+#pragma once
+
+enum KeyAction {
+	ACTION_NULL,
+	ACTION_UP,
+	ACTION_LEFT,
+	ACTION_DOWN,
+	ACTION_RIGHT,
+	ACTION_EXECUTE, // select, fire etc
+};
+
+bool input_key_once(enum KeyAction action);
+
+bool input_key_down(enum KeyAction action);

--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,7 @@ raylib = dependency('raylib')
 srcs = [
   'main.c',
   'game.c',
+  'input.c',
   'objects.c',
 ]
 executable('asteroids', srcs, install: true, dependencies: [raylib])


### PR DESCRIPTION
Given that we don't need to keep any state, we don't need to go through the hassle of adding a controller, let's just allow screens to fetch input as they see fit.

We have two use cases, single step (for navigation) and "pressed" for the game, so expose both

Fixes: https://github.com/refacto/asteroids/issues/18