### PR TITLE
add web build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,3 +77,56 @@ jobs:
         run: |
           meson setup build
           meson compile -C build
+
+  web:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup emsdk
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 3.1.64
+          actions-cache-folder: emsdk-cache
+
+      - name: Install meson + ninja
+        run: |
+          sudo apt update
+          sudo apt install -y ninja-build cmake
+          pip install meson
+
+      - name: Cache raylib (web)
+        id: cache-raylib-web
+        uses: actions/cache@v4
+        with:
+          path: /tmp/raylib-web
+          key: raylib-5.5-web-${{ hashFiles('.github/workflows/build.yml') }}
+
+      - name: Build raylib for web (cache miss)
+        if: steps.cache-raylib-web.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch 5.5 https://github.com/raysan5/raylib.git /tmp/raylib
+          emcmake cmake -S /tmp/raylib -B /tmp/raylib/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPLATFORM=Web \
+            -DCMAKE_INSTALL_PREFIX=/tmp/raylib-web
+          cmake --build /tmp/raylib/build --parallel
+          cmake --install /tmp/raylib/build
+
+      - name: Build asteroids (web)
+        run: |
+          export PKG_CONFIG_PATH=/tmp/raylib-web/lib/pkgconfig
+          meson setup build-web --cross-file cross/emscripten.ini --buildtype release
+          meson compile -C build-web
+
+      - name: Upload web artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: asteroids-web
+          path: |
+            build-web/asteroids.html
+            build-web/asteroids.js
+            build-web/asteroids.wasm
+            build-web/asteroids.data
+          if-no-files-found: ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,13 +120,35 @@ jobs:
           meson setup build-web --cross-file cross/emscripten.ini --buildtype release
           meson compile -C build-web
 
-      - name: Upload web artifact
-        uses: actions/upload-artifact@v4
+      - name: Stage Pages bundle
+        run: |
+          mkdir -p _site
+          cp build-web/asteroids.html _site/index.html
+          cp build-web/asteroids.js _site/
+          cp build-web/asteroids.wasm _site/
+          if [ -f build-web/asteroids.data ]; then
+            cp build-web/asteroids.data _site/
+          fi
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: asteroids-web
-          path: |
-            build-web/asteroids.html
-            build-web/asteroids.js
-            build-web/asteroids.wasm
-            build-web/asteroids.data
-          if-no-files-found: ignore
+          path: _site
+
+  deploy-pages:
+    needs: web
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/raylib-web
-          key: raylib-5.5-web-${{ hashFiles('.github/workflows/build.yml') }}
+          key: raylib-5.5-web-emsdk3.1.64
 
       - name: Build raylib for web (cache miss)
         if: steps.cache-raylib-web.outputs.cache-hit != 'true'

--- a/cross/emscripten.ini
+++ b/cross/emscripten.ini
@@ -1,0 +1,19 @@
+[binaries]
+c = 'emcc'
+cpp = 'em++'
+ar = 'emar'
+ranlib = 'emranlib'
+strip = 'emstrip'
+pkg-config = 'pkg-config'
+exe_wrapper = 'node'
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm32'
+endian = 'little'
+
+[built-in options]
+default_library = 'static'
+b_lundef = false
+b_pie = false

--- a/meson.build
+++ b/meson.build
@@ -13,8 +13,8 @@ project(
 )
 cc = meson.get_compiler('c')
 
-# sanitizers are not supported on Windows; leak sanitizer is Linux-only
-if host_machine.system() != 'windows'
+# sanitizers are not supported on Windows or Emscripten; leak sanitizer is Linux-only
+if host_machine.system() != 'windows' and host_machine.system() != 'emscripten'
   sanitize_flags = ['-fsanitize=address,undefined']
   if host_machine.system() != 'darwin'
     sanitize_flags += ['-fsanitize=leak']
@@ -87,4 +87,23 @@ srcs = [
   'globalActions.c',
   'soundFx.c',
 ]
-executable('asteroids', srcs, install: true, dependencies: [raylib])
+
+if host_machine.system() == 'emscripten'
+  web_link_args = [
+    '-sUSE_GLFW=3',
+    '-sASYNCIFY',
+    '-sTOTAL_MEMORY=64MB',
+    '-sFORCE_FILESYSTEM=1',
+    '-O3',
+  ]
+
+  executable(
+    'asteroids',
+    srcs,
+    dependencies: [raylib],
+    link_args: web_link_args,
+    name_suffix: 'html',
+  )
+else
+  executable('asteroids', srcs, install: true, dependencies: [raylib])
+endif


### PR DESCRIPTION
raylib runs on emscripten too, so why not have a web build as well

if this is merged, we should have an online version of main under refacto.github.io/asteroids