### PR TITLE
move to files() from bare strings for srcs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,7 @@ add_project_arguments(
 
 raylib = dependency('raylib')
 
-srcs = [
+srcs = files(
   'main.c',
   'game.c',
   'input.c',
@@ -91,5 +91,5 @@ srcs = [
   'score.c',
   'scoreboard.c',
   'drawHelpers.c',
-]
+)
 executable('asteroids', srcs, install: true, dependencies: [raylib])


### PR DESCRIPTION
this makes meson check for the file presence at configure time rather than at compile time, which makes for easier debugging should things go wrong