### PR TITLE
meson: don't spawn a console window on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -93,4 +93,10 @@ srcs = files(
   'scoreboard.c',
   'drawHelpers.c',
 )
-executable('asteroids', srcs, install: true, dependencies: [raylib])
+executable(
+  'asteroids',
+  srcs,
+  install: true,
+  dependencies: [raylib],
+  win_subsystem: 'windows', # on windows, don't spawn a console window
+)


### PR DESCRIPTION
windows has ["subsystems" ](https://learn.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem?view=msvc-170) which defaults to console on meson (aka TUI). That doesn't make sense for us, so pivot to a GUI app